### PR TITLE
PXP-2325 fix(operator): Added missing chapter to the side menu

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -204,6 +204,8 @@ params:
             link: /resources/operator/#1-docker-compose
           - name: Cloud Automation
             link: /resources/operator/#2-cloud-automation
+          - name: Creating a New Data Dictionary
+            link: /resources/operator/#3-creating-a-new-data-dictionary
   userMenu:
     title: Gen3 Users
     content:


### PR DESCRIPTION
The chapter "Creating a New Data Dictionary" was missing in the side menu