### PR TITLE
fix/moz height

### DIFF
--- a/static/css/footer.css
+++ b/static/css/footer.css
@@ -12,6 +12,7 @@
 
 .g3-footer__logo-wrapper {
   display: flex;
+  align-items: center;
   flex-grow: 1;
 }
 

--- a/static/css/header.css
+++ b/static/css/header.css
@@ -68,7 +68,6 @@
 .g3-header__logo-img {
   height: inherit;
   height: -webkit-fill-available;
-  height: -moz-available;
 }
 
 .g3-header__navbar {

--- a/static/css/header.css
+++ b/static/css/header.css
@@ -295,7 +295,6 @@
   margin: auto;
   height: inherit;
   height: -webkit-fill-available;
-  height: -moz-available;
 }
 
 .g3-md-header__title_bar {


### PR DESCRIPTION
Remove wrong options for `height`. Also fixed footer logo css since IE doesn't support `margin: auto`

### Bug Fixes
- fix wrongly displayed header logo in FireFox
- fix wrongly displayed footer logo in IE 11