### PR TITLE
Add "source ~/.bash_profile" step to Gen3Client setup guide

### DIFF
--- a/content/resources/user/gen3-client.md
+++ b/content/resources/user/gen3-client.md
@@ -47,6 +47,7 @@ No installation is necessary. Simply download the correct version for your opera
 3. Add the unzipped executable to a directory, for example: `~/.gen3/gen3-client.exe`.
 4. Open a terminal window.
 5. Add the directory containing the executable to your Path environment variable by entering this command in the terminal: `echo 'export PATH=$PATH:~/.gen3' >> ~/.bash_profile`.
+6. Run `source ~/.bash_profile` or restart your terminal.
 
 Now you can execute the program by opening a terminal window and entering the command `gen3-client`.
 


### PR DESCRIPTION

### Improvements
- Add `source ~/.bash_profile` step to Gen3Client setup guide
