### PR TITLE
Fixing errors encountered by new version of Hugo

### DIFF
--- a/content/community/events/Gen3workshop.adoc
+++ b/content/community/events/Gen3workshop.adoc
@@ -6,7 +6,7 @@ linktitle: /community/events/Gen3Workshop
 layout: single
 ---
 
-
+{{% agenda %}}
 
 <br>
 = Gen3 Community Forum Agenda {Draft}
@@ -272,3 +272,6 @@ GA4GH standards and interop
 
 |6:15-7:00pm CDT | *Discussion of Future Community Development*
 |===
+
+
+{{% /agenda %}}

--- a/content/community/events/Gen3workshop.adoc
+++ b/content/community/events/Gen3workshop.adoc
@@ -6,7 +6,7 @@ linktitle: /community/events/Gen3Workshop
 layout: single
 ---
 
-{{% agenda %}}
+
 
 <br>
 = Gen3 Community Forum Agenda {Draft}

--- a/content/community/events/gen3forum_202210_old.md
+++ b/content/community/events/gen3forum_202210_old.md
@@ -6,7 +6,7 @@ linktitle: /community/events/gen3forum_2022210
 layout: single
 ---
 
-
+{{% agenda %}}
 
 <br>
 
@@ -92,3 +92,5 @@ The forum will meet for three days, three hours each day, and will include prese
    <td> Discussion of Future Community Development <ul> <li> Community Manager </li> <li> Management of prioritized feature description documents </li> <li> Monthly calls </li> <li> Slack community channel </li> <li> Newsletter </li> </ul> </td>
   </tr>
 </table>
+
+{{% /agenda %}}

--- a/content/community/events/gen3forum_202210_old.md
+++ b/content/community/events/gen3forum_202210_old.md
@@ -6,7 +6,7 @@ linktitle: /community/events/gen3forum_2022210
 layout: single
 ---
 
-{{% agenda %}}
+
 
 <br>
 

--- a/content/community/events/gen3forum_202210_post.md
+++ b/content/community/events/gen3forum_202210_post.md
@@ -6,7 +6,7 @@ linktitle: /community/events/gen3forum_202221
 layout: single
 ---
 
-{{% agenda %}}
+
 
 <br>
 

--- a/content/community/events/gen3forum_202210_post.md
+++ b/content/community/events/gen3forum_202210_post.md
@@ -6,7 +6,7 @@ linktitle: /community/events/gen3forum_202221
 layout: single
 ---
 
-
+{{% agenda %}}
 
 <br>
 
@@ -215,3 +215,5 @@ layout: single
       <a href="https://youtu.be/jYCKC1R_evE?t=1983">&#x1F3A5;</a></td>
   </tr>
 </table>
+
+{{% /agenda %}}

--- a/content/community/events/gen3forum_20230301.md
+++ b/content/community/events/gen3forum_20230301.md
@@ -6,7 +6,7 @@ linktitle: /community/events/gen3forum_20230301
 layout: single
 ---
 
-{{% agenda %}}
+
 
 <br>
 

--- a/content/community/events/gen3forum_20230301.md
+++ b/content/community/events/gen3forum_20230301.md
@@ -7,6 +7,7 @@ layout: single
 ---
 
 
+{{% agenda %}}
 
 <br>
 
@@ -51,3 +52,5 @@ We will take you through the current best practices for setting up and configuri
   </tr>
 
 </table>
+
+{{% /agenda %}}

--- a/content/community/events/gen3forum_20230706.md
+++ b/content/community/events/gen3forum_20230706.md
@@ -9,7 +9,7 @@ layout: single
 
 
 
-
+{{% agenda %}}
 
 <br>
 
@@ -35,7 +35,7 @@ Gen3 supports a flexible graph-based data model, which can be customized for a w
 
 [Register Here](https://uchicago.zoom.us/meeting/register/tJIucuytpz8qHdUEbRhdcOZFWD5XnC68iebE#/registration)
 
-
+{{% /agenda %}}
 
 <!-- * Introduction to Gen3 Data Models (Michael Fitzsimons, Robert Grossman - Center for Translational Data Science, University of Chicago)
 * Presentations from Data Commons

--- a/content/community/events/gen3forum_20230706.md
+++ b/content/community/events/gen3forum_20230706.md
@@ -9,7 +9,7 @@ layout: single
 
 
 
-{{% agenda %}}
+
 
 <br>
 

--- a/content/community/events/gen3forum_20230906.md
+++ b/content/community/events/gen3forum_20230906.md
@@ -8,7 +8,7 @@ layout: single
 
 
 
-
+{{% agenda %}}
 
 <br>
 
@@ -25,7 +25,7 @@ layout: single
 * Security practices for Gen3 and applications (Plamen Martinov - Chief Technology Officer; Open Commons Consortium)
 * Securing Cloud-Native and Kubernetes (Colin Griffin - Founder, Chief Engineer; Krumware)
 
-
+{{% /agenda %}}
 
 
 

--- a/content/community/events/gen3forum_20230906.md
+++ b/content/community/events/gen3forum_20230906.md
@@ -8,7 +8,7 @@ layout: single
 
 
 
-{{% agenda /%}}
+
 
 <br>
 

--- a/content/community/events/gen3forum_20230906.md
+++ b/content/community/events/gen3forum_20230906.md
@@ -8,7 +8,7 @@ layout: single
 
 
 
-
+{{% agenda /%}}
 
 <br>
 

--- a/content/community/events/gen3forum_20230906.md
+++ b/content/community/events/gen3forum_20230906.md
@@ -9,7 +9,6 @@ layout: single
 
 
 
-{{% agenda %}}
 
 <br>
 

--- a/content/resources/user/access-data.md
+++ b/content/resources/user/access-data.md
@@ -6,6 +6,8 @@ layout: withtoc
 menuname: userMenu
 ---
 
+{{% markdownwrapper %}}
+
 # Accessing and Exploring Metadata and Downloading Data Files
 
 * * *
@@ -112,3 +114,5 @@ The [__Gen3Submission__ class](https://uc-cdis.github.io/gen3sdk-python/_build/h
 Entire structured data records can be exported as a JSON or TSV file using the [__Gen3Submission__ Python SDK class](https://uc-cdis.github.io/gen3sdk-python/_build/html/submission.html). The [`export_record`](https://github.com/uc-cdis/gen3sdk-python/blob/master/gen3/submission.py#L223) function will export a single structured metadata record in a specific node of a specific project, whereas the [`export_node`](https://github.com/uc-cdis/gen3sdk-python/blob/master/gen3/submission.py#L255) function will export all the structured metadata records in a specified node of a specific project.
 
 More SDK examples and how to get started with the SDK can be also found in the [analyze-data section](/resources/user/analyze-data/#4-using-the-gen3-sdk).
+
+{{% /markdownwrapper %}}

--- a/content/resources/user/access-data.md
+++ b/content/resources/user/access-data.md
@@ -5,7 +5,7 @@ linktitle: /resources/user
 layout: withtoc
 menuname: userMenu
 ---
-{{% markdownwrapper %}}
+
 # Accessing and Exploring Metadata and Downloading Data Files
 
 * * *

--- a/content/resources/user/analyze-data.md
+++ b/content/resources/user/analyze-data.md
@@ -5,7 +5,7 @@ linktitle: /resources/user
 layout: withtoc
 menuname: userMenu
 ---
-{{% markdownwrapper %}}
+
 # Data Analysis in a Gen3 Data Commons
 * * *
 

--- a/content/resources/user/analyze-data.md
+++ b/content/resources/user/analyze-data.md
@@ -6,6 +6,8 @@ layout: withtoc
 menuname: userMenu
 ---
 
+{{% markdownwrapper %}}
+
 # Data Analysis in a Gen3 Data Commons
 * * *
 
@@ -264,3 +266,5 @@ Below are three tutorial Jupyter Notebooks that demonstrate various SDK function
 3. Download data files and metadata using the gen3-client and the Gen3 SDK, respectively, and bring them into the workspace. Run gene expression analysis and statistical analysis on the data files and metadata, respectively, and plot the outcome in different scenarios. This Jupyter [Data Analysis Notebook](notebook3_gen3datacommonsio.html) uses data hosted on the generic Data Commons [gen3.datacommons.io](gen3.datacommons.io). Upload this notebook as an [.ipynb file](notebook3_gen3datacommonsio.ipynb) to the workspace of the Generic Data Commons and start your analysis.  Note, that bringing in files into the workspace as explained in this notebook can be also achieved on selected Data Commons by clicking the "Export to Workspace" button on the Exploration Page; please also note, that once files are exported from the Exploration page, users do not need to authenticate anymore in the workspace.
 
 When finished, please, shut down the workspace server by clicking the "Terminate Workspace" button.
+
+{{% /markdownwrapper %}}

--- a/content/resources/user/gen3-client.md
+++ b/content/resources/user/gen3-client.md
@@ -5,7 +5,7 @@ linktitle: /resources/user
 layout: withtoc
 menuname: userMenu
 ---
-{{% markdownwrapper %}}
+
 
 # Download and Upload Files Using the Gen3-client
 

--- a/content/resources/user/gen3-client.md
+++ b/content/resources/user/gen3-client.md
@@ -6,6 +6,7 @@ layout: withtoc
 menuname: userMenu
 ---
 
+{{% markdownwrapper %}}
 
 # Download and Upload Files Using the Gen3-client
 
@@ -661,3 +662,5 @@ So, by adding the directory containing the gen3-client program to your PATH vari
 Most programs require some sort of user input to run properly. Some programs will prompt you for input after execution, while other programs are sent this input during execution as "flags" (AKA "arguments" or "options"). The gen3-client uses the latter method of sending user input as command arguments during program execution.
 
 For example, when configuring a profile with the client, the user must specify the `configure` option and also specify the profile name, API endpoint, and credentials file by adding the flags `--profile`, `--apiendpoint` and `--cred` to the end of the command (see [configuring a profile section](#2-configure-a-profile-with-credentials) above for specific examples).
+
+{{% /markdownwrapper %}}

--- a/content/resources/user/query-data.md
+++ b/content/resources/user/query-data.md
@@ -5,7 +5,7 @@ linktitle: /resources/user
 layout: withtoc
 menuname: userMenu
 ---
-{{% markdownwrapper %}}
+
 # Querying Metadata in the Gen3 Submission Portal using GraphiQL
 * * *
 

--- a/content/resources/user/query-data.md
+++ b/content/resources/user/query-data.md
@@ -6,6 +6,8 @@ layout: withtoc
 menuname: userMenu
 ---
 
+{{% markdownwrapper %}}
+
 # Querying Metadata in the Gen3 Submission Portal using GraphiQL
 * * *
 
@@ -226,3 +228,5 @@ query ($filter: JSON) {
   }
 }
 ```
+
+{{% /markdownwrapper %}}

--- a/content/resources/user/submit-data.md
+++ b/content/resources/user/submit-data.md
@@ -5,7 +5,8 @@ linktitle: /resources/user
 layout: withtoc
 menuname: userMenu
 ---
-{{% markdownwrapper /%}}
+{{% markdownwrapper %}}
+
 # Submitting Data Files and Linking Metadata in a Gen3 Data Commons
 * * *
 
@@ -293,3 +294,5 @@ For example, the following link would download a single TSV containing all the `
 https://gen3.datacommons.io/api/v0/submission/example/training/export/?node_label=core_metadata_collection&format=tsv
 
 The links in the downloaded TSV can be updated by filling in the submitter_ids of the corresponding parent records, saving, and re-submitting the file to the data portal website using 'Upload File' as done in [step 4](#more-about-specifying-required-links).
+
+{{% /markdownwrapper %}}

--- a/content/resources/user/submit-data.md
+++ b/content/resources/user/submit-data.md
@@ -5,7 +5,7 @@ linktitle: /resources/user
 layout: withtoc
 menuname: userMenu
 ---
-{{% markdownwrapper %}}
+{{% markdownwrapper /%}}
 # Submitting Data Files and Linking Metadata in a Gen3 Data Commons
 * * *
 

--- a/content/resources/user/submit-data/sower.md
+++ b/content/resources/user/submit-data/sower.md
@@ -6,6 +6,8 @@ layout: withtoc
 menuname: userMenu
 ---
 
+{{% markdownwrapper %}}
+
 # Linking Data from external Data Clouds to Gen3 Data Commons
 ***
 
@@ -22,3 +24,5 @@ Data files that are stored on other cloud services, such as Amazon Web Services 
     > __Note:__ Users in the Gen3-Community have published [repos](https://github.com/jacquayj/gen3-s3indexer-extramural) that index large pre-existing s3 buckets (disclaimer: CTDS is not responsible for the content and opinions on the third-party repos).
 
 4. If applicable, submission files can be prepared for the Gen3 graph model as described on the [data submission page](https://gen3.org/resources/user/submit-data/#4-submit-additional-project-metadata) or briefly described here. You can choose between two options: a) create a `core_metadata_collection` entity, link it to the `data_file` node, and submit your data files directly to the `data_file` node. b) Create a structured chain of metadata according to the Gen3 graph model to obtain the link to the `data_file` node. Then, you can submit the files to the `data_file` node.
+
+{{% /markdownwrapper %}}

--- a/content/resources/user/submit-data/sower.md
+++ b/content/resources/user/submit-data/sower.md
@@ -5,7 +5,7 @@ linktitle: /resources/user/submit-data
 layout: withtoc
 menuname: userMenu
 ---
-{{% markdownwrapper %}}
+
 # Linking Data from external Data Clouds to Gen3 Data Commons
 ***
 


### PR DESCRIPTION

I updated Hugo and now the site won't build locally as Hugo apparently no longer accepts "unclosed shortcodes"

I have closed the following shortcodes and all the pages seem to work now both locally and on http://alpha.gen3.org/

{{% markdownwrapper %}}

{{% agenda %}}

