### PR TITLE
Update hugo to newer version and deprecate a function in css.html

### DIFF
--- a/.github/workflows/hugo_ci.yaml
+++ b/.github/workflows/hugo_ci.yaml
@@ -14,9 +14,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
-        hugo-version: '0.100.2'
+        hugo-version: '0.148.0'
         extended: true
 
     - name: Setup Asciidoctor

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x && \
     apt-get install curl -y git wget ca-certificates
 
 RUN set -x && \
-    curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_amd64.deb -o hugo_extended.deb && \
+    curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb -o hugo_extended.deb && \
     apt install ./hugo_extended.deb && \
     hugo version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/cdis/golang:1.18-bullseye as builder
 
-ENV HUGO_VERSION 0.100.2
+ENV HUGO_VERSION 0.148.0
 ENV PATH=/usr/local/hugo:${PATH}
 ENV BASE_URL=
 
@@ -10,7 +10,7 @@ RUN set -x && \
     apt-get install curl -y git wget ca-certificates
 
 RUN set -x && \
-    curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb -o hugo_extended.deb && \
+    curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_amd64.deb -o hugo_extended.deb && \
     apt install ./hugo_extended.deb && \
     hugo version
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Gen3.org website for describing the Gen3 platform.
 
 ```bash
 # Install hugo
-brew install hugo
+brew install hugo asciidoctor
 # Build site and start Hugo server locally
 hugo server -D -b localhost
 ```

--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,7 @@ linktitle: about
 date: 2018-09-04T22:16:21-05:00
 g3Teaser:
   fig: figs/kv.svg
-  title: Gen3 is a data platform for building data commons and data meshes. 
+  title: Gen3 is a data platform for building data commons and data meshes.
   detail: The Gen3 platform consists of open-source software services that support the emergence of healthy data ecosystems by enabling the interoperation and creation of cloud-based data resources, including data commons and analysis workspaces. Gen3 aims to accelerate and democratize the process of scientific discovery by making it easy to manage, analyze, harmonize, and share large and complex datasets in the cloud.
   button1:
     caption: Experience Demo
@@ -17,7 +17,7 @@ g3Teaser:
 g3Feature:
   f1:
     title: Host, Manage, and Share your Data
-    detail: Gen3 empowers you to host, manage, and share data with researchers, developers, and health organizations. The Gen3 platform supports ingestion of virtual any data format, including both large objects and clinical and phenotype metadata. With Gen3, you can receive and quality control data by a customizable data model and generate globally unique IDs for data objects.
+    detail: Gen3 empowers you to host, manage, and share data with researchers, developers, and health organizations. The Gen3 platform supports ingestion of virtually any data format, including both large objects and clinical and phenotype metadata. With Gen3, you can receive and quality control data by a customizable data model and generate globally unique IDs for data objects.
   f2:
     title: Explore, Export, and Analyze Data in Workspaces
     detail: Explore data on our Data Commons using built-in faceted search tools, send custom queries, create and export subject-level data cohorts, or collaboratively analyze the selected data in a secure cloud environment.

--- a/content/resources/gen3-features.md
+++ b/content/resources/gen3-features.md
@@ -4,7 +4,7 @@ title: Gen3 Features
 linktitle: /resources/gen3-features
 layout: withtoc
 menuname: featuresMenu
-date: 2023-06-280T15:20:00-6:00
+date: 2023-06-28T15:20:00-06:00
 ---
 
 # A list of Gen3 features

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -4,5 +4,5 @@
 <link rel="stylesheet" href="{{ "css/style.css" | relURL }}" />
 <link rel="stylesheet" href="{{ "css/header.css" | relURL }}" />
 <link rel="stylesheet" href="{{ "css/footer.css" | relURL }}" />
-{{ $style := resources.Get "sass/slider.scss" | resources.ToCSS | resources.Minify }}
+{{ $style := resources.Get "sass/slider.scss" | css.Sass | resources.Minify }}
 <link rel="stylesheet" href="{{ $style.RelPermalink }}">

--- a/static/img/logos/gen3_new_logo_white.svg
+++ b/static/img/logos/gen3_new_logo_white.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="195px"
+   height="89px"
+   viewBox="0 0 195 89"
+   version="1.1"
+   id="svg251"
+   sodipodi:docname="gen3-newlogo-blue-dark.svg"
+   inkscape:version="1.2 (dc2aeda, 2022-05-15)"
+   inkscape:export-filename="gen3-newlogo-blue-dark.png"
+   inkscape:export-xdpi="480"
+   inkscape:export-ydpi="480"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview253"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4.0326005"
+     inkscape:cx="69.558093"
+     inkscape:cy="46.124083"
+     inkscape:window-width="1920"
+     inkscape:window-height="968"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg251" />
+  <!-- Generator: Sketch 55 (78076) - https://sketchapp.com -->
+  <title
+     id="title221">Group 33</title>
+  <desc
+     id="desc223">Created with Sketch.</desc>
+  <defs
+     id="defs226">
+    <polygon
+       id="path-1"
+       points="0 0.0686 41.8857 0.0686 41.8857 69.0836 0 69.0836" />
+    <mask
+       id="mask-2"
+       fill="#ffffff">
+      <use
+         xlink:href="#path-1"
+         id="use229" />
+    </mask>
+  </defs>
+  <path
+     d="m 194.7646,61.4042 c 0,15.197 -12.205,27.527 -27.396,27.527 h -0.125 c -15.2,0 -27.405,-12.33 -27.405,-27.527 0,-2.242 1.867,-4.107 4.108,-4.107 2.242,0 4.115,1.865 4.115,4.107 0,10.715 8.592,19.305 19.307,19.305 10.584,0 19.181,-8.59 19.181,-19.305 0,-10.215 -9.471,-19.303 -20.428,-19.303 -1.498,0 -2.994,-0.873 -3.613,-2.246 -0.752,-1.367 -0.627,-2.986 0.252,-4.232 l 20.049,-27.403 h -38.863 c -2.241,0 -4.108,-1.869 -4.108,-4.113 0,-2.24 1.867,-4.107 4.108,-4.107 h 46.836 c 1.498,0 2.986,0.871 3.613,2.242 0.744,1.367 0.619,2.986 -0.25,4.232 l -20.68,28.399 c 12.088,3.117 21.299,14.076 21.299,26.531"
+     id="Fill-1"
+     fill="#d9c92e"
+     style="fill:#3283c8;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" />
+  <g
+     id="Clip-4"
+     transform="translate(0,-0.0684)"
+     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1" />
+  <path
+     d="m 41.8857,37.8886 v 26.189 c 0,1.702 -1.422,3.12 -3.123,3.12 -1.797,0 -3.119,-1.418 -3.119,-3.12 v -1.043 c -3.779,3.688 -8.981,6.049 -14.749,6.049 -11.441,0 -20.895,-9.357 -20.895,-20.892 v -27.133 c 0,-11.535 9.454,-20.99 20.895,-20.99 11.534,0 20.991,9.455 20.991,20.99 0,1.701 -1.422,3.119 -3.123,3.119 -1.797,0 -3.119,-1.418 -3.119,-3.119 0,-8.133 -6.619,-14.75 -14.749,-14.75 -8.037,0 -14.655,6.617 -14.655,14.75 v 27.133 c 0,8.035 6.618,14.654 14.655,14.654 8.13,0 14.749,-6.619 14.749,-14.654 v -7.184 h -13.803 c -1.701,0 -3.119,-1.418 -3.119,-3.119 0,-1.703 1.418,-3.123 3.119,-3.123 h 16.922 c 1.701,0 3.123,1.42 3.123,3.123"
+     id="Fill-3"
+     fill="#4f586e"
+     mask="url(#mask-2)"
+     transform="translate(0,-0.0684)"
+     style="fill-rule:evenodd;stroke:none;stroke-width:1;fill:#ffffff;fill-opacity:1" />
+  <path
+     d="m 57.4873,37.3456 v 23.543 h 22.129 c 1.697,0 3.117,1.418 3.117,3.121 0,1.701 -1.42,3.119 -3.117,3.119 h -25.25 c -1.795,0 -3.119,-1.418 -3.119,-3.119 V 4.5366 c 0,-1.701 1.324,-3.117 3.119,-3.117 h 25.25 c 1.697,0 3.117,1.416 3.117,3.117 0,1.704 -1.42,3.122 -3.117,3.122 h -22.129 v 23.447 h 22.129 c 1.697,0 3.117,1.42 3.117,3.121 0,1.795 -1.42,3.119 -3.117,3.119 z"
+     id="Fill-6"
+     fill="#4f586e"
+     style="fill-rule:evenodd;stroke:none;stroke-width:1;fill:#ffffff;fill-opacity:1" />
+  <path
+     d="m 122.5401,65.5331 -24.016,-48.031 v 46.613 c 0,1.793 -1.418,3.119 -3.119,3.119 -1.703,0 -3.121,-1.326 -3.121,-3.119 v -59.85 c 0,-1.418 0.945,-2.74 2.363,-3.025 1.42,-0.379 2.932,0.285 3.498,1.607 l 24.11,48.125 V 4.2651 c 0,-1.703 1.324,-3.121 3.121,-3.121 1.699,0 3.117,1.418 3.117,3.121 v 59.85 c 0,1.512 -1.039,2.74 -2.457,3.119 h -0.66 c -1.227,0 -2.268,-0.568 -2.836,-1.701"
+     id="Fill-8"
+     fill="#4f586e"
+     style="fill-rule:evenodd;stroke:none;stroke-width:1;fill:#ffffff;fill-opacity:1" />
+  <metadata
+     id="metadata3200">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>Group 33</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes
Doesn't work with Hugo earlier than `v0.128.0`. 

### Bug Fixes
updated the deprecated `resources.ToCSS` to `css.Sass`.

### Improvements

### Dependency updates
Hugo bumped to `0.148.0`;
hugo workflow bumped to `v3`; 

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
